### PR TITLE
alternate way to lay out table in example 7.2.5

### DIFF
--- a/book_chapters_LaTeX_original/functions.tex
+++ b/book_chapters_LaTeX_original/functions.tex
@@ -217,10 +217,14 @@ Functions are often represented as a \emph{table} of values.
 The following table represents the prices of items in a grocery store:
 
 \begin{center}
-\begin{tabular}{c|rr}
-item & \span price (in cents) \\
-\noalign{\hrule}
-$\var{apple}$ & \hskip 45pt 65 \\
+%\begin{tabular}{c|rr}
+%item & \span price (in cents) \\
+%\noalign{\hrule}
+%$\var{apple}$ & \hskip 45pt 65 \\
+\begin{tabular}{c|c}
+item & price (in cents) \\
+\hline
+$\var{apple}$ & 65 \\
 $\var{banana}$ & 83 \\
 $\var{cherry}$ & 7 \\
 $\var{donut}$ & 99 \\


### PR DESCRIPTION
I commented out the first 4 lines of the table in example 7.2.5 to show a way to do the
layout that looks okay in both PDF and HTML.

The PDF is not quite as good as it was because the prices line up differently.  It that
is acceptable, then the other tables can be done this way.

Note:
1) The original layout was {c|rr}
This makes no sense because there are 2 columns separated by a line, not 3 columns.
Doing it as {c|r} did not look good in the PDF, so I did {c|c}

2) The original \noalign{\hrule} may have looked okay in the PDF, but that is not the right
way to do it.  I switched to \hline, and this change should be made elsewhere, even if you
don't want to make these other changes.
