### PR TITLE
at sign in math index entries

### DIFF
--- a/book_chapters_LaTeX_original/actions.tex
+++ b/book_chapters_LaTeX_original/actions.tex
@@ -25,7 +25,7 @@ given by $(g, x)\rightarrow gx$, where
 \item $ex = x$ for all $x\in X$;
 \item $(g_1g_2)x = g_1(g_2x)$ for all $x\in X$ and all $g_1, g_2 \in G$.
 \end{enumerate}
-The set $X$  on which $G$ acts is called a  \bfii{$G$-set}.\index{$G$-set}
+The set $X$  on which $G$ acts is called a  \bfii{$G$-set}.\index{G-set@$G$-set}
 \end{defn}
 It is also possible to define right group actions, but in this chapter we'll focus just on left group actions.\index{Actions!left and right}  Following are some more examples of group actions.
 
@@ -98,7 +98,7 @@ From the previous exercise it's pretty clear that for any two faces of a cube th
 
 \begin{defn}\label{GEquivalent}
 If a group $G$ acts on a set $X$ and $x, y \in X$, then $x$ is said to be
-\bfii{ $G$-equivalent\/}\index{$G$-equivalent} to $y$ if there exists a
+\bfii{ $G$-equivalent\/}\index{G-equiv@$G$-equivalent} to $y$ if there exists a
 $g \in G$ such that $gx =y$. We write $x \sim_Gy$ or $x \sim y$ if
 two elements are $G$-equivalent.
 \end{defn}

--- a/book_chapters_LaTeX_original/summation_notation.tex
+++ b/book_chapters_LaTeX_original/summation_notation.tex
@@ -745,7 +745,7 @@ $(\textbf{a} \times \textbf{b})_i$ as
 Note that we do not bother to indicate that the indices $i,j,k$ run from 1 to 3: this is understood by the nature of $\epsilon_{ijk}$.
 
 \subsubsection*{BAC-CAB Rule}
-As a final example, suppose we want to prove what is known as the $BAC-CAB$ rule\index{$BAC-CAB$ rule}, which states:
+As a final example, suppose we want to prove what is known as the $BAC-CAB$ rule\index{BAC-CAB@$BAC-CAB$ rule}, which states:
 \[ \textbf{a} \times \left( \textbf{b} \times \textbf{c} \right) = \textbf{b} \left( \textbf{a} \cdot \textbf{c} \right) - \textbf{c} \left( \textbf{a} \cdot \textbf{b} \right). \]
 To prove this we can go two different routes: the brute-force method or the symmetry method.  Let's start with the brute force method.
 


### PR DESCRIPTION
If you want to have an index entry for $D_N$, you do it like this:
\index{DN@$D_N}
where the letters before the at sign are used purely for alphabetizing purposes.

There were 3 index entries where this change was needed.
