### PR TITLE
term*, one example, one correction

### DIFF
--- a/book_chapters_LaTeX_original/aafmt.tex
+++ b/book_chapters_LaTeX_original/aafmt.tex
@@ -136,8 +136,14 @@
 
 % New commands defined by CPT (legacy from P & C)
 \newcommand{\var}[1]{\sf{#1}} 
+
+\usepackage{ifthen}
+\newcommand{\term}[1]{\ifthenelse{\equal{#1}{*}}%
+  {\terminology}%
+  {\textbf{\textit{{#1}}}}%
+}
 \newcommand{\terminology}[1]{\textbf{\textit{{#1}}}}
-\newcommand{\term}[1]{\terminology{#1}} 
+%\newcommand{\term}[1]{\terminology{#1}} 
 \newcommand{\hint}[1]{\emph{#1}} 
 \newcommand{\cref}[1]{\sf{\term{ #1}}} %%%% Cross-reference, legacy from P & C
 \newcommand{\Cref}[1]{\sf{\term{ #1}}} %%%% Cross-reference, legacy from P & C

--- a/book_chapters_LaTeX_original/algcodes.tex
+++ b/book_chapters_LaTeX_original/algcodes.tex
@@ -51,7 +51,7 @@ transmitting and receiving coded messages (Figure~\ref{encoding}).
 \end{figure}
 Uncoded messages consist of a sequence of symbols, such as letters or characters. Typically these symbols 
 are re-expressed in a binary code (such as ASCII)\index{Code!binary}\index{Code!ASCII}, so that the message can be considered as a sequence of
-binary digits (binary digits are referred to as \term{bits}\index{Bits}). This sequence is divided up into chunks of $m$ bits apiece: these binary $m$-tuples
+binary digits (binary digits are referred to as \term*{bits}\index{Bits}). This sequence is divided up into chunks of $m$ bits apiece: these binary $m$-tuples
 are referred to as \term{message words} \index{Message word}. Message words are
 then encoded into \term{codewords}\index{Codeword} of $n$ bits apiece by a device
 called an \term{encoder}\index{Encoder}. The Codewords are transmitted over a channel and received by a receiver.

--- a/book_chapters_LaTeX_original/permute.tex
+++ b/book_chapters_LaTeX_original/permute.tex
@@ -215,7 +215,7 @@ The \term{order of a set} $Y$ is the number of elements of $Y$, and is written a
 Now let $X = \{1,2,\ldots, n\}$, and  consider any set $Y$ with $|Y| = n$. We could do a similar ``face-lifting'' as above to show that  $S_X \equiv S_Y$.  So the group $S_X$ is equivalent to the permutations of \emph{any} set of $n$ elements.
 
 \begin{notation}{sym_group_n_letters}
-Let $X=\{ 1, 2, \ldots, n\}$. Instead of writing $S_X$, we write $S_n$\label{symmetricgroup}.  $S_n$ is called the \term{symmetric group\index{Group!symmetric} on $n$ letters}.
+Let $X=\{ 1, 2, \ldots, n\}$. Instead of writing $S_X$, we write $S_n$\label{symmetricgroup}.  $S_n$ is called the \term{symmetric group}\index{Group!symmetric} on $n$ letters.
 \end{notation}
 
 \subsection{Isomorphic groups}


### PR DESCRIPTION
I added a macro for \term*, which (currenty) does the same thing in LaTeX but
in HTML it does not make the automatic links wherever those words occur.

I did one example: \term*{bits}

You can no longer put \index{} inside \term{}, so I fixed that in one place.

A new HTML version has been made.  Please check if it is okay.
